### PR TITLE
Always run services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,11 @@ version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +194,15 @@ dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -443,6 +457,18 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1028,6 +1054,8 @@ dependencies = [
  "clap 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap_generate 3.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 5.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1052,6 +1080,7 @@ dependencies = [
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+"checksum cc 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
@@ -1064,6 +1093,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 "checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum ctrlc 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
@@ -1097,6 +1127,7 @@ dependencies = [
 "checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)" = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
+"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum normalize-line-endings 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 "checksum notify 5.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b00c0b65188bffb5598c302e19b062feb94adef02c31f15622a163c95d673c3"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ build = "build.rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 crossbeam = "=0.7.3"
+crossbeam-channel = "0.4.2"
 walkdir = "2"
 notify = { version = "=5.0.0-pre.2", features = ["serde"] }
 clap = "3.0.0-beta.1"
@@ -30,6 +31,7 @@ seahash = "4.0.0"
 rayon = "1.3.0"
 bincode = "1.2.1"
 run_script = "0.6.3"
+ctrlc = { version = "3.1.4", features = ["termination"] }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ Specifies a command to run upon successful build of the target. It should be a s
 
 This keyword is meant to enable the execution of long-lasting commands, such as servers.
 
-If the targets to run do not define services, `zinoma` will automatically exit after all builds are complete.
-On the contrary, if at least one target defines a service, then, `zinoma` will keep running even after all builds are complete in order to keep the service alive.
+If the targets to run do not define services, `zinoma` will automatically exit after all builds ran to completion.
+On the contrary, if at least one target defines a service, `zinoma` will keep running even after all builds completed, so that the services can remain alive.
 
 In watch mode (when the `--watch` flag is passed to `zinoma`), services are restarted every time the target `build` runs to completion.
 
@@ -243,8 +243,9 @@ This directory should be ignored in your version control.
 #### Watch mode (`--watch`)
 
 Žinoma offers a watch mode which can be enabled with the `--watch` option of the command line.
-Instead of exiting, Žinoma will keep an eye open on the targets' `input_paths`,
-and will re-execute the relevant targets in case filesystem changes are detected.
+
+If the watch mode is enabled, `zinoma` will not exit after the build flow completion.
+Instead, it will keep an eye open on the targets' `input_paths` and will re-execute the relevant targets in case filesystem changes are detected.
 
 #### Clean flag (`--clean`)
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ Specifies a command to run upon successful build of the target. It should be a s
 
 This keyword is meant to enable the execution of long-lasting commands, such as servers.
 
-Services are only executed in watch mode (when the `--watch` flag is passed to `zinoma`). They are restarted every time the target `build` runs to completion.
+If the targets to run do not define services, `zinoma` will automatically exit after all builds are complete.
+On the contrary, if at least one target defines a service, then, `zinoma` will keep running even after all builds are complete in order to keep the service alive.
+
+In watch mode (when the `--watch` flag is passed to `zinoma`), services are restarted every time the target `build` runs to completion.
 
 __Example__
 
@@ -196,7 +199,7 @@ targets:
     service: npm start
 ```
 
-In this example, `$ zinoma npm_server --watch` will run `npm install` and then `npm start`.
+In this example, `$ zinoma npm_server` will run `npm install` and then `npm start`.
 
 ### Command line
 
@@ -239,14 +242,9 @@ This directory should be ignored in your version control.
 
 #### Watch mode (`--watch`)
 
-The execution of `zinoma` normally ends as soon as all the specified targets are built.
-
-However, Žinoma also offers a watch mode which can be enabled with the `--watch` option of the command line.
+Žinoma offers a watch mode which can be enabled with the `--watch` option of the command line.
 Instead of exiting, Žinoma will keep an eye open on the targets' `input_paths`,
 and will re-execute the relevant targets in case filesystem changes are detected.
-
-When watch mode is enabled, Žinoma also runs the services of the built targets.
-A service will be restarted every time its target's build completes.
 
 #### Clean flag (`--clean`)
 

--- a/src/engine/build_state.rs
+++ b/src/engine/build_state.rs
@@ -1,5 +1,5 @@
-use super::builder::BuildReport;
 use super::incremental::IncrementalRunResult;
+use super::BuildReport;
 use crate::domain::{Target, TargetId};
 use anyhow::{Error, Result};
 use crossbeam::channel::{unbounded, Receiver, Sender, TryRecvError};

--- a/src/engine/build_state.rs
+++ b/src/engine/build_state.rs
@@ -15,10 +15,8 @@ impl<'a> TargetBuildStates<'a> {
         }
     }
 
-    pub fn set_builds_invalidated(&mut self, target_ids: &[TargetId]) {
-        for &target_id in target_ids {
-            self.build_states[target_id].build_invalidated();
-        }
+    pub fn set_build_invalidated(&mut self, target_id: TargetId) {
+        self.build_states[target_id].build_invalidated();
     }
 
     pub fn set_build_started(&mut self, target_id: TargetId) {

--- a/src/engine/build_state.rs
+++ b/src/engine/build_state.rs
@@ -2,23 +2,20 @@ use super::incremental::IncrementalRunResult;
 use super::BuildReport;
 use crate::domain::{Target, TargetId};
 use anyhow::{Error, Result};
-use crossbeam::channel::{unbounded, Receiver, Sender, TryRecvError};
+use crossbeam::channel::{Receiver, TryRecvError};
 
 pub struct TargetBuildStates<'a> {
     targets: &'a [Target],
+    build_report_events: Receiver<BuildReport>,
     build_states: Vec<TargetBuildState>,
-    pub tx: Sender<BuildReport>,
-    rx: Receiver<BuildReport>,
 }
 
 impl<'a> TargetBuildStates<'a> {
-    pub fn new(targets: &'a [Target]) -> Self {
-        let (tx, rx) = unbounded();
+    pub fn new(targets: &'a [Target], build_report_events: Receiver<BuildReport>) -> Self {
         Self {
             targets,
+            build_report_events,
             build_states: vec![TargetBuildState::new(); targets.len()],
-            tx,
-            rx,
         }
     }
 
@@ -57,7 +54,7 @@ impl<'a> TargetBuildStates<'a> {
     }
 
     pub fn get_finished_build(&mut self) -> Result<Option<BuildReport>> {
-        match self.rx.try_recv() {
+        match self.build_report_events.try_recv() {
             Ok(result) => {
                 let target_build_state = &mut self.build_states[result.target_id];
                 if let IncrementalRunResult::Run(Err(_)) = &result.result {

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -1,80 +1,34 @@
-use super::incremental::{IncrementalRunResult, IncrementalRunner};
-use crate::domain::{Target, TargetId};
-use anyhow::{Context, Result};
-use crossbeam::channel::Sender;
-use crossbeam::thread::Scope;
-use run_script::{IoOptions, ScriptOptions};
 use std::time::Instant;
 
-pub struct TargetBuilder<'a> {
-    incremental_runner: IncrementalRunner<'a>,
-}
+use anyhow::{Context, Result};
+use run_script::{IoOptions, ScriptOptions};
 
-impl<'a> TargetBuilder<'a> {
-    pub fn new(incremental_runner: IncrementalRunner<'a>) -> Self {
-        Self { incremental_runner }
+use crate::domain::Target;
+
+pub fn build_target(target: &Target) -> Result<()> {
+    if let Some(script) = &target.build {
+        let target_start = Instant::now();
+        log::info!("{} - Building", &target.name);
+
+        let mut options = ScriptOptions::new();
+        options.exit_on_error = true;
+        options.output_redirection = IoOptions::Inherit;
+        options.working_directory = Some(target.path.to_path_buf());
+
+        let (code, _output, _error) = run_script::run(&script, &vec![], &options)
+            .with_context(|| "Script execution error")?;
+
+        if code != 0 {
+            return Err(anyhow::anyhow!("Build failed for target {}", target.name));
+        }
+
+        let target_build_duration = target_start.elapsed();
+        log::info!(
+            "{} - Built (took: {}ms)",
+            target.name,
+            target_build_duration.as_millis()
+        );
     }
 
-    pub fn build(&'a self, scope: &Scope<'a>, target: &'a Target, tx: &Sender<BuildReport>) {
-        let tx = tx.clone();
-        scope.spawn(move |_| {
-            build_target(target, &self.incremental_runner, &tx)
-                .with_context(|| format!("Error building target {}", target.id))
-                .unwrap()
-        });
-    }
-}
-
-pub fn build_target(
-    target: &Target,
-    incremental_runner: &IncrementalRunner,
-    tx: &Sender<BuildReport>,
-) -> Result<()> {
-    let result = incremental_runner
-        .run(&target, || {
-            let target_start = Instant::now();
-
-            if let Some(script) = &target.build {
-                log::info!("{} - Building", &target.name);
-
-                let mut options = ScriptOptions::new();
-                options.exit_on_error = true;
-                options.output_redirection = IoOptions::Inherit;
-                options.working_directory = Some(target.path.to_path_buf());
-
-                let (code, _output, _error) = run_script::run(&script, &vec![], &options)
-                    .with_context(|| "Build execution error")?;
-
-                if code != 0 {
-                    return Err(anyhow::anyhow!("Build failed for target {}", target.name));
-                }
-            }
-
-            let target_build_duration = target_start.elapsed();
-            log::info!(
-                "{} - Built (took: {}ms)",
-                target.name,
-                target_build_duration.as_millis()
-            );
-            Ok(())
-        })
-        .with_context(|| "Incremental build error")?;
-
-    if let IncrementalRunResult::Skipped = result {
-        log::info!("{} - Build skipped (Not Modified)", target.name);
-    }
-
-    tx.send(BuildReport::new(target.id, result))
-        .with_context(|| "Sender error")
-}
-
-pub struct BuildReport {
-    pub target_id: TargetId,
-    pub result: IncrementalRunResult<Result<()>>,
-}
-
-impl BuildReport {
-    pub fn new(target_id: TargetId, result: IncrementalRunResult<Result<()>>) -> Self {
-        Self { target_id, result }
-    }
+    Ok(())
 }

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use crossbeam::channel::{Receiver, tick};
+use crossbeam::channel::{tick, Receiver};
 use run_script::{IoOptions, ScriptOptions};
 use std::time::Duration;
 

--- a/src/engine/builder.rs
+++ b/src/engine/builder.rs
@@ -1,11 +1,13 @@
 use std::time::Instant;
 
 use anyhow::{Context, Result};
+use crossbeam::channel::{Receiver, tick};
 use run_script::{IoOptions, ScriptOptions};
+use std::time::Duration;
 
 use crate::domain::Target;
 
-pub fn build_target(target: &Target) -> Result<()> {
+pub fn build_target(target: &Target, termination_events: Receiver<()>) -> Result<()> {
     if let Some(script) = &target.build {
         let target_start = Instant::now();
         log::info!("{} - Building", &target.name);
@@ -15,19 +17,33 @@ pub fn build_target(target: &Target) -> Result<()> {
         options.output_redirection = IoOptions::Inherit;
         options.working_directory = Some(target.path.to_path_buf());
 
-        let (code, _output, _error) = run_script::run(&script, &vec![], &options)
-            .with_context(|| "Script execution error")?;
+        let mut process = run_script::spawn(&script, &vec![], &options)
+            .with_context(|| "Build script execution error")?;
 
-        if code != 0 {
-            return Err(anyhow::anyhow!("Build failed for target {}", target.name));
+        let ticks = tick(Duration::from_millis(10));
+
+        loop {
+            crossbeam_channel::select! {
+                recv(ticks) -> _ => {
+                    if let Some(exit_status) = process.try_wait()? {
+                        if !exit_status.success() {
+                            return Err(anyhow::anyhow!("Build failed for target {} ({})", target.name, exit_status));
+                        }
+                        let target_build_duration = target_start.elapsed();
+                        log::info!(
+                            "{} - Built (took: {}ms)",
+                            target.name,
+                            target_build_duration.as_millis()
+                        );
+                        break;
+                    }
+                },
+                recv(termination_events) -> _ => {
+                    process.kill().with_context(|| format!("Failed to kill build process for {}", target.name))?;
+                    return Err(anyhow::anyhow!("Build cancelled for target {}", target.name));
+                },
+            }
         }
-
-        let target_build_duration = target_start.elapsed();
-        log::info!(
-            "{} - Built (took: {}ms)",
-            target.name,
-            target_build_duration.as_millis()
-        );
     }
 
     Ok(())

--- a/src/engine/incremental/mod.rs
+++ b/src/engine/incremental/mod.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(PartialEq)]
 pub enum IncrementalRunResult<T> {
@@ -17,12 +17,12 @@ pub enum IncrementalRunResult<T> {
     Run(T),
 }
 
-pub struct IncrementalRunner<'a> {
-    checksum_dir: &'a Path,
+pub struct IncrementalRunner {
+    checksum_dir: PathBuf,
 }
 
-impl<'a> IncrementalRunner<'a> {
-    pub fn new(checksum_dir: &'a Path) -> Self {
+impl IncrementalRunner {
+    pub fn new(checksum_dir: PathBuf) -> Self {
         Self { checksum_dir }
     }
 
@@ -125,7 +125,7 @@ impl<'a> IncrementalRunner<'a> {
     }
 
     pub fn remove_checksum_dir(&self) -> Result<()> {
-        match fs::remove_dir_all(self.checksum_dir) {
+        match fs::remove_dir_all(&self.checksum_dir) {
             Ok(_) => {}
             Err(e) if e.kind() == ErrorKind::NotFound => {}
             Err(e) => {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -95,12 +95,12 @@ impl Engine {
                 }
             }
 
-            match termination_events
-                .recv()
-                .with_context(|| "Failed to listen to termination event")?
-            {
-                _ => services_runner.terminate_all_services(),
-            };
+            if services_runner.has_running_services() {
+                termination_events
+                    .recv()
+                    .with_context(|| "Failed to listen to termination event")?;
+                services_runner.terminate_all_services();
+            }
 
             Ok(())
         })

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -82,11 +82,7 @@ impl Engine {
 
             Ok(())
         })
-        .map_err(|_| {
-            anyhow::anyhow!("Unknown crossbeam parallelism failure (thread panicked)")
-        })??;
-
-        Ok(())
+        .map_err(|_| anyhow::anyhow!("Unknown crossbeam parallelism failure (thread panicked)"))?
     }
 
     fn build_ready_targets<'a, 's>(

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -53,7 +53,7 @@ impl Engine {
                         if let IncrementalRunResult::Run(Err(e)) = build_report.result {
                             log::warn!("{} - {}", target.name, e);
                         } else {
-                            services_runner.restart_service(scope, target.clone())?;
+                            services_runner.restart_service(target)?;
                         }
                     }
                   },
@@ -85,7 +85,7 @@ impl Engine {
                         }
 
                         let target = &self.targets[build_report.target_id];
-                        services_runner.start_service(scope, target.clone())?;
+                        services_runner.start_service(target)?;
                     }
                   },
                   recv(termination_events) -> _ => {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -29,12 +29,11 @@ impl Engine {
         }
     }
 
-    pub fn watch(&self) -> Result<()> {
+    pub fn watch(self) -> Result<()> {
         let watcher =
             TargetsWatcher::new(&self.targets).with_context(|| "Failed to set up file watcher")?;
 
         let mut services_runner = ServicesRunner::new(&self.targets);
-
         let mut target_build_states = TargetBuildStates::new(&self.targets);
 
         crossbeam::scope(|scope| -> Result<()> {
@@ -61,9 +60,8 @@ impl Engine {
         .map_err(|_| anyhow::anyhow!("Unknown crossbeam parallelism failure (thread panicked)"))?
     }
 
-    pub fn build(&self) -> Result<()> {
+    pub fn build(self) -> Result<()> {
         let mut services_runner = ServicesRunner::new(&self.targets);
-
         let mut target_build_states = TargetBuildStates::new(&self.targets);
 
         crossbeam::scope(|scope| {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,6 +1,7 @@
 mod build_state;
 mod builder;
 pub mod incremental;
+mod process;
 mod service;
 mod watcher;
 

--- a/src/engine/process.rs
+++ b/src/engine/process.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+use std::process::Child;
+
+pub fn kill_and_wait(process: &mut Child) -> Result<()> {
+    process.kill()?;
+    process.wait()?;
+    Ok(())
+}

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -1,26 +1,26 @@
 use crate::domain::Target;
 use anyhow::{Context, Result};
-use crossbeam::channel::{unbounded, Receiver, Sender};
+use crossbeam::channel::{bounded, Receiver, Sender};
 use crossbeam::thread::Scope;
 use run_script::{IoOptions, ScriptOptions};
 
 pub struct ServicesRunner {
-    tx_channels: Vec<Option<Sender<RunSignal>>>,
+    terminate_service_senders: Vec<Option<Sender<()>>>,
 }
 
 impl ServicesRunner {
     pub fn new(targets: &[Target]) -> Self {
         Self {
-            tx_channels: vec![None; targets.len()],
+            terminate_service_senders: vec![None; targets.len()],
         }
     }
 
     pub fn restart_service(&mut self, scope: &Scope, target: Target) -> Result<()> {
         // If already running, send a kill signal.
-        if let Some(service_tx) = &self.tx_channels[target.id] {
-            service_tx
-                .send(RunSignal::Kill)
-                .with_context(|| "Failed to send Kill signal to running process")?;
+        if let Some(terminate_service_sender) = &self.terminate_service_senders[target.id] {
+            terminate_service_sender
+                .send(())
+                .with_context(|| "Failed to send Kill signal to running service")?;
         }
 
         self.start_service(scope, target)
@@ -28,17 +28,27 @@ impl ServicesRunner {
 
     pub fn start_service(&mut self, scope: &Scope, target: Target) -> Result<()> {
         if target.service.is_some() {
-            let (service_tx, service_rx) = unbounded();
-            self.tx_channels[target.id] = Some(service_tx);
+            let (terminate_service_sender, terminate_service_events) = bounded(0);
+            self.terminate_service_senders[target.id] = Some(terminate_service_sender);
 
-            scope.spawn(move |_| run_target_service(target, service_rx).unwrap());
+            scope.spawn(move |_| run_target_service(target, terminate_service_events).unwrap());
         }
 
         Ok(())
     }
+
+    pub fn terminate_all_services(&mut self) {
+        for terminate_service_sender in &self.terminate_service_senders {
+            if let Some(terminate_service_sender) = terminate_service_sender {
+                terminate_service_sender.send(()).unwrap_or_else(|e| {
+                    println!("Failed to send Kill signal to running process: {}", e)
+                });
+            }
+        }
+    }
 }
 
-fn run_target_service(target: Target, rx: Receiver<RunSignal>) -> Result<()> {
+fn run_target_service(target: Target, terminate_service_events: Receiver<()>) -> Result<()> {
     if let Some(script) = &target.service {
         log::info!("{} - Starting service", target.name);
 
@@ -50,19 +60,15 @@ fn run_target_service(target: Target, rx: Receiver<RunSignal>) -> Result<()> {
         let mut handle = run_script::spawn(&script, &vec![], &options)
             .with_context(|| format!("Failed to start service {}", target.name))?;
 
-        match rx.recv().with_context(|| "Receiver error")? {
-            RunSignal::Kill => {
-                log::trace!("{} - Stopping service", target.name);
-                handle
-                    .kill()
-                    .with_context(|| format!("Failed to kill service {}", target.name))?;
-            }
-        }
+        // Wait for termination event
+        terminate_service_events
+            .recv()
+            .with_context(|| "Receiver error")?;
+        log::trace!("{} - Stopping service", target.name);
+        handle
+            .kill()
+            .with_context(|| format!("Failed to kill service {}", target.name))?;
     }
 
     Ok(())
-}
-
-enum RunSignal {
-    Kill,
 }

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -1,74 +1,53 @@
 use crate::domain::Target;
 use anyhow::{Context, Result};
-use crossbeam::channel::{bounded, Receiver, Sender};
-use crossbeam::thread::Scope;
 use run_script::{IoOptions, ScriptOptions};
+use std::process::Child;
 
 pub struct ServicesRunner {
-    terminate_service_senders: Vec<Option<Sender<()>>>,
+    service_processes: Vec<Option<Child>>,
 }
 
 impl ServicesRunner {
     pub fn new(targets: &[Target]) -> Self {
         Self {
-            terminate_service_senders: vec![None; targets.len()],
+            service_processes: (0..targets.len()).map(|_| None).collect(),
         }
     }
 
-    pub fn restart_service(&mut self, scope: &Scope, target: Target) -> Result<()> {
-        // If already running, send a kill signal.
-        if let Some(terminate_service_sender) = &self.terminate_service_senders[target.id] {
-            terminate_service_sender
-                .send(())
-                .with_context(|| "Failed to send Kill signal to running service")?;
+    pub fn restart_service(&mut self, target: &Target) -> Result<()> {
+        if let Some(Some(service_process)) = self.service_processes.get_mut(target.id) {
+            log::trace!("{} - Stopping service", target.name);
+            service_process.kill().with_context(|| format!("Failed to kill service {}", target.name))?;
         }
 
-        self.start_service(scope, target)
+        self.start_service(target)
     }
 
-    pub fn start_service(&mut self, scope: &Scope, target: Target) -> Result<()> {
-        if target.service.is_some() {
-            let (terminate_service_sender, terminate_service_events) = bounded(0);
-            self.terminate_service_senders[target.id] = Some(terminate_service_sender);
+    pub fn start_service(&mut self, target: &Target) -> Result<()> {
+        if let Some(script) = &target.service {
+            log::info!("{} - Starting service", target.name);
 
-            scope.spawn(move |_| run_target_service(target, terminate_service_events).unwrap());
+            let mut options = ScriptOptions::new();
+            options.exit_on_error = true;
+            options.output_redirection = IoOptions::Inherit;
+            options.working_directory = Some(target.path.to_path_buf());
+
+            let service_process = run_script::spawn(&script, &vec![], &options)
+                .with_context(|| format!("Failed to start service {}", target.name))?;
+
+            self.service_processes[target.id] = Some(service_process);
         }
 
         Ok(())
     }
 
     pub fn terminate_all_services(&mut self) {
-        for terminate_service_sender in &self.terminate_service_senders {
-            if let Some(terminate_service_sender) = terminate_service_sender {
-                terminate_service_sender.send(()).unwrap_or_else(|e| {
+        for service_process in self.service_processes.iter_mut() {
+            if let Some(service_process) = service_process {
+                service_process.kill().unwrap_or_else(|e| {
                     println!("Failed to send Kill signal to running process: {}", e)
                 });
             }
         }
     }
-}
-
-fn run_target_service(target: Target, terminate_service_events: Receiver<()>) -> Result<()> {
-    if let Some(script) = &target.service {
-        log::info!("{} - Starting service", target.name);
-
-        let mut options = ScriptOptions::new();
-        options.exit_on_error = true;
-        options.output_redirection = IoOptions::Inherit;
-        options.working_directory = Some(target.path.to_path_buf());
-
-        let mut handle = run_script::spawn(&script, &vec![], &options)
-            .with_context(|| format!("Failed to start service {}", target.name))?;
-
-        // Wait for termination event
-        terminate_service_events
-            .recv()
-            .with_context(|| "Receiver error")?;
-        log::trace!("{} - Stopping service", target.name);
-        handle
-            .kill()
-            .with_context(|| format!("Failed to kill service {}", target.name))?;
-    }
-
-    Ok(())
 }

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -1,3 +1,4 @@
+use super::process;
 use crate::domain::Target;
 use anyhow::{Context, Result};
 use run_script::{IoOptions, ScriptOptions};
@@ -21,7 +22,7 @@ impl ServicesRunner {
     pub fn restart_service(&mut self, target: &Target) -> Result<()> {
         if let Some(Some(service_process)) = self.service_processes.get_mut(target.id) {
             log::trace!("{} - Stopping service", target.name);
-            kill_and_wait(service_process)
+            process::kill_and_wait(service_process)
                 .with_context(|| format!("Failed to kill service {}", target.name))?;
         }
 
@@ -49,15 +50,9 @@ impl ServicesRunner {
     pub fn terminate_all_services(&mut self) {
         for service_process in self.service_processes.iter_mut() {
             if let Some(service_process) = service_process {
-                kill_and_wait(service_process)
+                process::kill_and_wait(service_process)
                     .unwrap_or_else(|e| println!("Failed to kill service: {}", e));
             }
         }
     }
-}
-
-pub fn kill_and_wait(process: &mut Child) -> Result<()> {
-    process.kill()?;
-    process.wait()?;
-    Ok(())
 }

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -14,10 +14,16 @@ impl ServicesRunner {
         }
     }
 
+    pub fn has_running_services(&self) -> bool {
+        self.service_processes.iter().any(Option::is_some)
+    }
+
     pub fn restart_service(&mut self, target: &Target) -> Result<()> {
         if let Some(Some(service_process)) = self.service_processes.get_mut(target.id) {
             log::trace!("{} - Stopping service", target.name);
-            service_process.kill().with_context(|| format!("Failed to kill service {}", target.name))?;
+            service_process
+                .kill()
+                .with_context(|| format!("Failed to kill service {}", target.name))?;
         }
 
         self.start_service(target)

--- a/src/engine/service.rs
+++ b/src/engine/service.rs
@@ -48,11 +48,16 @@ impl ServicesRunner {
     }
 
     pub fn terminate_all_services(&mut self) {
-        for service_process in self.service_processes.iter_mut() {
-            if let Some(service_process) = service_process {
-                process::kill_and_wait(service_process)
-                    .unwrap_or_else(|e| println!("Failed to kill service: {}", e));
-            }
+        for service_process in self.service_processes.iter_mut().flatten() {
+            service_process
+                .kill()
+                .unwrap_or_else(|e| println!("Failed to kill service: {}", e));
+        }
+        for service_process in self.service_processes.iter_mut().flatten() {
+            service_process
+                .wait()
+                .map(|_exit_status| ())
+                .unwrap_or_else(|e| println!("Failed to wait for service termination: {}", e));
         }
     }
 }

--- a/src/engine/watcher.rs
+++ b/src/engine/watcher.rs
@@ -1,47 +1,50 @@
 use crate::domain::{Target, TargetId};
 use anyhow::{Context, Error, Result};
-use crossbeam::channel::{unbounded, Receiver, TryRecvError};
-use notify::{ErrorKind, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use crossbeam::channel::Sender;
+use notify::{ErrorKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
-pub struct TargetsWatcher<'a> {
-    target_watchers: Vec<TargetWatcher<'a>>,
+pub struct TargetsWatcher {
+    _target_watchers: Vec<TargetWatcher>,
 }
 
-impl<'a> TargetsWatcher<'a> {
-    pub fn new(targets: &'a [Target]) -> Result<Self> {
+impl TargetsWatcher {
+    pub fn new(targets: &[Target], target_invalidated_sender: Sender<TargetId>) -> Result<Self> {
         let mut target_watchers = Vec::new();
         for target in targets.iter() {
-            target_watchers.push(TargetWatcher::new(target)?);
+            target_watchers.push(TargetWatcher::new(
+                target,
+                target_invalidated_sender.clone(),
+            )?);
         }
-        Ok(Self { target_watchers })
-    }
-
-    pub fn get_invalidated_targets(&self) -> Result<Vec<TargetId>> {
-        let mut invalidated_targets = Vec::new();
-
-        for (target_id, target_watcher) in self.target_watchers.iter().enumerate() {
-            if target_watcher.is_invalidated()? {
-                invalidated_targets.push(target_id);
-            }
-        }
-
-        Ok(invalidated_targets)
+        Ok(Self {
+            _target_watchers: target_watchers,
+        })
     }
 }
 
-pub struct TargetWatcher<'a> {
-    target: &'a Target,
-    rx: Receiver<notify::Result<Event>>,
+pub struct TargetWatcher {
     _watcher: RecommendedWatcher,
 }
 
-impl<'a> TargetWatcher<'a> {
-    pub fn new(target: &'a Target) -> Result<Self> {
-        let (tx, rx) = unbounded();
+impl TargetWatcher {
+    pub fn new(target: &Target, target_invalidated_sender: Sender<TargetId>) -> Result<Self> {
+        let target_id = target.id;
         let mut watcher: RecommendedWatcher =
-            Watcher::new_immediate(move |e| tx.send(e).with_context(|| "Sender error").unwrap())
-                .with_context(|| "Error creating watcher")?;
+            Watcher::new_immediate(move |result: notify::Result<notify::Event>| {
+                if result
+                    .unwrap()
+                    .paths
+                    .iter()
+                    .any(|path| !is_tmp_editor_file(path))
+                {
+                    target_invalidated_sender
+                        .send(target_id)
+                        .with_context(|| "Sender error")
+                        .unwrap();
+                }
+            })
+            .with_context(|| "Error creating watcher")?;
 
         for path in &target.input_paths {
             match watcher.watch(path, RecursiveMode::Recursive) {
@@ -66,33 +69,7 @@ impl<'a> TargetWatcher<'a> {
             }
         }
 
-        Ok(Self {
-            target,
-            rx,
-            _watcher: watcher,
-        })
-    }
-
-    pub fn is_invalidated(&self) -> Result<bool> {
-        match self.rx.try_recv() {
-            Ok(event) => {
-                let paths: Vec<_> = event
-                    .unwrap()
-                    .paths
-                    .into_iter()
-                    .filter(|path| !is_tmp_editor_file(path))
-                    .collect();
-
-                let invalidated = !paths.is_empty();
-                if invalidated {
-                    log::trace!("{} - Invalidated by {:?}", self.target.name, paths)
-                }
-
-                Ok(invalidated)
-            }
-            Err(TryRecvError::Empty) => Ok(false),
-            Err(e) => Err(Error::new(e).context("Watcher received error")),
-        }
+        Ok(Self { _watcher: watcher })
     }
 }
 

--- a/src/engine/watcher.rs
+++ b/src/engine/watcher.rs
@@ -4,25 +4,6 @@ use crossbeam::channel::Sender;
 use notify::{ErrorKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
-pub struct TargetsWatcher {
-    _target_watchers: Vec<TargetWatcher>,
-}
-
-impl TargetsWatcher {
-    pub fn new(targets: &[Target], target_invalidated_sender: Sender<TargetId>) -> Result<Self> {
-        let mut target_watchers = Vec::new();
-        for target in targets.iter() {
-            target_watchers.push(TargetWatcher::new(
-                target,
-                target_invalidated_sender.clone(),
-            )?);
-        }
-        Ok(Self {
-            _target_watchers: target_watchers,
-        })
-    }
-}
-
 pub struct TargetWatcher {
     _watcher: RecommendedWatcher,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,17 +45,12 @@ fn main() -> Result<()> {
     if requested_targets.is_some() {
         let engine = Engine::new(targets, incremental_runner);
 
-        crossbeam::scope(|scope| {
-            if arg_matches.is_present(cli::arg::WATCH) {
-                engine.watch(scope).with_context(|| "Watch error")
-            } else {
-                engine.build(scope).with_context(|| "Build error")
-            }
-        })
-        .map_err(|_| {
-            anyhow::anyhow!("Unknown crossbeam parallelism failure (thread panicked)")
-        })??;
+        if arg_matches.is_present(cli::arg::WATCH) {
+            engine.watch().with_context(|| "Watch error")
+        } else {
+            engine.build().with_context(|| "Build error")
+        }
+    } else {
+        Ok(())
     }
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     let targets = config.into_targets(project_dir, &requested_targets)?;
 
     let checksum_dir = project_dir.join(".zinoma");
-    let incremental_runner = IncrementalRunner::new(&checksum_dir);
+    let incremental_runner = IncrementalRunner::new(checksum_dir);
 
     if arg_matches.is_present(cli::arg::CLEAN) {
         incremental_runner.clean_checksums(&targets)?;


### PR DESCRIPTION
Zinoma would only run services when watch would be enabled.

Would should instead always run the services (this behavior is more logical). In build mode (as opposed to watch mode), if no requested target has a service, exit automatically on successful build.

This PR also improves handling of termination, especially when a build script fails to complete.