### PR TITLE
Ignore .zinoma files for incremental build & watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,11 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dunce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1136,7 @@ dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1175,6 +1181,7 @@ dependencies = [
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+"checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum filetime 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 "checksum float-cmp 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da62c4f1b81918835a8c6a484a397775fff5953fe83529afd51b05f5c6a6617d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bincode = "1.2.1"
 run_script = "0.6.3"
 ctrlc = { version = "3.1.4", features = ["termination"] }
 schemars = "0.7.6"
+dunce = "1.0.0"
 
 [target.'cfg(all(not(target_env = "msvc"), target_pointer_width = "64"))'.dependencies]
 jemallocator = "0.3.2"

--- a/src/config/yaml/mod.rs
+++ b/src/config/yaml/mod.rs
@@ -103,7 +103,7 @@ impl Config {
 }
 
 fn canonicalize_dir(dir: &Path) -> Result<PathBuf> {
-    dir.canonicalize().map_err(|e| {
+    dunce::canonicalize(dir).map_err(|e| {
         let context = if e.kind() == ErrorKind::NotFound {
             format!("Directory {} does not exist", dir.display())
         } else {

--- a/src/engine/incremental/fs_hash.rs
+++ b/src/engine/incremental/fs_hash.rs
@@ -1,3 +1,4 @@
+use super::is_in_checksum_dir;
 use anyhow::{Context, Result};
 use rayon::prelude::*;
 use seahash::SeaHasher;
@@ -51,7 +52,7 @@ fn list_files(paths: &[PathBuf]) -> HashSet<PathBuf> {
                 Err(e) => log::debug!("Failed to walk dir {}: {}", path.display(), e),
                 Ok(entry) => {
                     let path = entry.path().to_path_buf();
-                    if path.is_file() {
+                    if path.is_file() && !is_in_checksum_dir(&path) {
                         files.insert(path);
                     }
                 }

--- a/src/engine/incremental/mod.rs
+++ b/src/engine/incremental/mod.rs
@@ -12,7 +12,7 @@ use std::io::ErrorKind;
 use std::path::{self, Path, PathBuf};
 
 /// Name of the directory in which Žinoma stores checksums of the targets inputs and outputs.
-const CHECKSUM_DIR_NAME: &'static str = ".zinoma";
+const CHECKSUM_DIR_NAME: &str = ".zinoma";
 
 #[derive(PartialEq)]
 pub enum IncrementalRunResult<T> {
@@ -46,6 +46,21 @@ pub fn is_in_checksum_dir(path: &Path) -> bool {
         path::Component::Normal(name) => name == CHECKSUM_DIR_NAME,
         _ => false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_in_checksum_dir;
+    use std::path::Path;
+
+    #[test]
+    fn test_is_in_checksum_dir() {
+        assert!(is_in_checksum_dir(Path::new(".zinoma/my/file.json")));
+        assert!(is_in_checksum_dir(Path::new(
+            "/my/project/.zinoma/my/file.json"
+        )));
+        assert!(!is_in_checksum_dir(Path::new("/my/file.json")));
+    }
 }
 
 fn get_checksum_dir_path(project_dir: &Path) -> PathBuf {

--- a/src/engine/incremental/mod.rs
+++ b/src/engine/incremental/mod.rs
@@ -9,7 +9,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::{self, Path, PathBuf};
+
+/// Name of the directory in which Žinoma stores checksums of the targets inputs and outputs.
+const CHECKSUM_DIR_NAME: &'static str = ".zinoma";
 
 #[derive(PartialEq)]
 pub enum IncrementalRunResult<T> {
@@ -38,8 +41,15 @@ where
     Ok(IncrementalRunResult::Run(result))
 }
 
+pub fn is_in_checksum_dir(path: &Path) -> bool {
+    path.components().any(|component| match component {
+        path::Component::Normal(name) => name == CHECKSUM_DIR_NAME,
+        _ => false,
+    })
+}
+
 fn get_checksum_dir_path(project_dir: &Path) -> PathBuf {
-    project_dir.join(".zinoma")
+    project_dir.join(CHECKSUM_DIR_NAME)
 }
 
 fn get_checksum_file_path(target: &Target) -> PathBuf {

--- a/src/engine/watcher.rs
+++ b/src/engine/watcher.rs
@@ -1,3 +1,4 @@
+use super::incremental::is_in_checksum_dir;
 use crate::domain::{Target, TargetId};
 use anyhow::{Context, Error, Result};
 use crossbeam::channel::Sender;
@@ -17,7 +18,7 @@ impl TargetWatcher {
                     .unwrap()
                     .paths
                     .iter()
-                    .any(|path| !is_tmp_editor_file(path))
+                    .any(|path| !is_tmp_editor_file(path) && !is_in_checksum_dir(path))
                 {
                     target_invalidated_sender
                         .send(target_id)

--- a/tests/integ/root_input_path/source.txt
+++ b/tests/integ/root_input_path/source.txt
@@ -1,0 +1,1 @@
+Content of my source file

--- a/tests/integ/root_input_path/zinoma.yml
+++ b/tests/integ/root_input_path/zinoma.yml
@@ -1,0 +1,4 @@
+targets:
+  print_source:
+    input_paths: [.]
+    build: cat source.txt


### PR DESCRIPTION
Resolves #36

Also, fixes a blocking issue on Windows. The issue was detected by the new integration tests.